### PR TITLE
Support caching of cohorts with cachey.

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -2,6 +2,7 @@ name: flox-tests
 channels:
   - conda-forge
 dependencies:
+  - cachey
   - codecov
   - dask-core
   - netcdf4

--- a/flox/cache.py
+++ b/flox/cache.py
@@ -1,0 +1,11 @@
+from functools import partial
+
+try:
+    import cachey
+    import dask
+
+    # 1MB cache
+    cohorts_cache = cachey.Cache(1e6)
+    memoize = partial(cohorts_cache.memoize, key=dask.base.tokenize)
+except ImportError:
+    memoize = lambda x: x

--- a/flox/core.py
+++ b/flox/core.py
@@ -22,6 +22,7 @@ import pandas as pd
 
 from . import aggregations, xrdtypes
 from .aggregations import Aggregation, _atleast_1d, _get_fill_value, generic_aggregate
+from .cache import memoize
 from .xrutils import is_duck_array, is_duck_dask_array, isnull
 
 if TYPE_CHECKING:
@@ -118,9 +119,14 @@ def _get_optimal_chunks_for_groups(chunks, labels):
     return tuple(newchunks)
 
 
+@memoize
 def find_group_cohorts(labels, chunks, merge=True, method="cohorts"):
     """
-    Finds groups labels that occur together: "cohorts"
+    Finds groups labels that occur together aka "cohorts"
+
+    If available, results are cached in a 1MB cache managed by `cachey`.
+    This allows us to be quick when repeatedly calling groupby_reduce
+    for arrays with the same chunking (e.g. an xarray Dataset).
 
     Parameters
     ----------

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
 
 [options.extras_require]
 all =
+    cachey
     dask
     xarray
 test =

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -554,6 +554,7 @@ def test_rechunk_for_blockwise(inchunks, expected):
     assert _get_optimal_chunks_for_groups(inchunks, labels) == expected
 
 
+@requires_dask
 @pytest.mark.parametrize(
     "expected, labels, chunks, merge",
     [


### PR DESCRIPTION
Closes #51

Can't use lru_cache because numpy arrays are not hashable.