### PR TITLE
Use blockwise followed by direct reduction

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -276,7 +276,12 @@ def test_groupby_agg_dask(func, shape, array_chunks, group_chunks, add_nan, dtyp
         labels[:3] = np.nan  # entire block is NaN when group_chunks=3
         labels[-2:] = np.nan
 
-    kwargs = dict(func=func, expected_groups=[0, 1, 2], fill_value=123)
+    # TODO?
+    if func in ["any", "all"]:
+        fv = False
+    else:
+        fv = 123
+    kwargs = dict(func=func, expected_groups=[0, 1, 2], fill_value=fv)
 
     expected, _ = groupby_reduce(array.compute(), labels, engine="numpy", **kwargs)
     actual, _ = groupby_reduce(array.compute(), labels, engine=engine, **kwargs)


### PR DESCRIPTION
Instead of map-reducing the groupby-reduction , 
1. apply the `chunk` groupby reduction blockwise; 
2. reindex to expected_groups; 
3. then map-reduce the `combine` reduction.

i.e. xhistogram-style. So much cleaner!