### PR TITLE
Fix mixing of blockwise and map-reduce strategies.

### DIFF
--- a/docs/source/user-stories/climatology-hourly.ipynb
+++ b/docs/source/user-stories/climatology-hourly.ipynb
@@ -1701,7 +1701,8 @@
    "id": "494766c2-305a-4518-b2b7-a85bcc7fd5b2",
    "metadata": {},
    "source": [
-    "View the performance report [here](https://rawcdn.githack.com/dcherian/flox/592c46ba0bb859f732968b68426b6332caebc213/docs/source/user-stories/hourly-climatology.html)"
+    "View the performance report\n",
+    "[here](https://rawcdn.githack.com/dcherian/flox/592c46ba0bb859f732968b68426b6332caebc213/docs/source/user-stories/hourly-climatology.html)\n"
    ]
   }
  ],

--- a/flox/core.py
+++ b/flox/core.py
@@ -1583,6 +1583,10 @@ def groupby_reduce(
                     array_subset = np.take(array_subset, idxr, axis=ax)
                 numblocks = np.prod([len(array_subset.chunks[ax]) for ax in axis])
 
+                # First deep copy becasue we might be doping blockwise,
+                # which sets agg.finalize=None, then map-reduce (GH102)
+                agg = copy.deepcopy(agg)
+
                 # get final result for these groups
                 r, *g = partial_agg(
                     array_subset,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -828,3 +828,17 @@ def test_datetime_binning():
     expected = pd.cut(by, time_bins).codes.copy()
     expected[0] = 14  # factorize doesn't return -1 for nans
     assert_equal(group_idx, expected)
+
+
+@requires_dask
+def test_map_reduce_blockwise_mixed():
+    t = pd.date_range("2000-01-01", "2000-12-31", freq="D").to_series()
+    data = t.dt.dayofyear
+    actual = groupby_reduce(
+        dask.array.from_array(data.values, chunks=365),
+        t.dt.month,
+        func="mean",
+        method="split-reduce",
+    )
+    expected = groupby_reduce(data, t.dt.month, func="mean")
+    assert_equal(expected, actual)


### PR DESCRIPTION
agg.finalize was set to None when blockwise, this
wouldn't work when followed by map-reduce

Closes #102