### PR TITLE
xarray issue with reduction on not all present expected_groups

### DIFF
--- a/flox/core.py
+++ b/flox/core.py
@@ -1327,13 +1327,10 @@ def _factorize_multiple(by, expected_groups, by_is_dask):
         )
         found_groups = tuple(None if is_duck_dask_array(b) else pd.unique(b) for b in by)
         grp_shape = tuple(len(e) for e in expected_groups)
+        final_groups = tuple(expect.to_numpy() for expect in expected_groups)
     else:
         group_idx, found_groups, grp_shape = factorize_(by, **kwargs)
-
-    final_groups = tuple(
-        found if expect is None else expect.to_numpy()
-        for found, expect in zip(found_groups, expected_groups)
-    )
+        final_groups = found_groups
 
     if any(grp is None for grp in final_groups):
         raise ValueError("Please provide expected_groups when grouping by a dask array.")

--- a/flox/xarray.py
+++ b/flox/xarray.py
@@ -310,6 +310,14 @@ def xarray_reduce(
 
         result, *groups = groupby_reduce(array, *by, func=func, **kwargs)
 
+        expected_groups = kwargs['expected_groups']
+        fill_value = kwargs['fill_value']
+        ind=[np.where(expected.isin(group))[0] for group,expected in zip(groups,expected_groups)]
+        target_shape = result.shape[:-len(expected_groups)]+tuple(len(e) for e in expected_groups)
+        target=np.full(target_shape,fill_value,dtype=result.dtype)
+        target[(...,*np.ix_(*ind),)]=result
+        result=target
+
         if requires_numeric:
             if is_npdatetime:
                 return result.astype(dtype) + offset

--- a/flox/xarray.py
+++ b/flox/xarray.py
@@ -311,12 +311,15 @@ def xarray_reduce(
         result, *groups = groupby_reduce(array, *by, func=func, **kwargs)
 
         expected_groups = kwargs['expected_groups']
-        fill_value = kwargs['fill_value']
-        ind=[np.where(expected.isin(group))[0] for group,expected in zip(groups,expected_groups)]
-        target_shape = result.shape[:-len(expected_groups)]+tuple(len(e) for e in expected_groups)
-        target=np.full(target_shape,fill_value,dtype=result.dtype)
-        target[(...,*np.ix_(*ind),)]=result
-        result=target
+
+        if not all(len(expected)==len(group) for group,expected in zip(groups,expected_groups)):
+            fill_value = kwargs['fill_value']
+            assert fill_value is not None
+            ind=[np.where(expected.isin(group))[0] for group,expected in zip(groups,expected_groups)]
+            target_shape = result.shape[:-len(expected_groups)]+tuple(len(e) for e in expected_groups)
+            target=np.full(target_shape,fill_value,dtype=result.dtype)
+            target[(...,*np.ix_(*ind),)]=result
+            result=target
 
         if requires_numeric:
             if is_npdatetime:

--- a/flox/xarray.py
+++ b/flox/xarray.py
@@ -310,16 +310,26 @@ def xarray_reduce(
 
         result, *groups = groupby_reduce(array, *by, func=func, **kwargs)
 
-        expected_groups = kwargs['expected_groups']
+        expected_groups = kwargs["expected_groups"]
 
-        if not all(len(expected)==len(group) for group,expected in zip(groups,expected_groups)):
-            fill_value = kwargs['fill_value']
+        if not all(len(expected) == len(group) for group, expected in zip(groups, expected_groups)):
+            fill_value = kwargs["fill_value"]
             assert fill_value is not None
-            ind=[np.where(expected.isin(group))[0] for group,expected in zip(groups,expected_groups)]
-            target_shape = result.shape[:-len(expected_groups)]+tuple(len(e) for e in expected_groups)
-            target=np.full(target_shape,fill_value,dtype=result.dtype)
-            target[(...,*np.ix_(*ind),)]=result
-            result=target
+            ind = [
+                np.where(expected.isin(group))[0]
+                for group, expected in zip(groups, expected_groups)
+            ]
+            target_shape = result.shape[: -len(expected_groups)] + tuple(
+                len(e) for e in expected_groups
+            )
+            target = np.full(target_shape, fill_value, dtype=result.dtype)
+            target[
+                (
+                    ...,
+                    *np.ix_(*ind),
+                )
+            ] = result
+            result = target
 
         if requires_numeric:
             if is_npdatetime:


### PR DESCRIPTION
The test below fails before this commit and succeeds after.
However getting the correct fill_value, if any, and avoiding computation so the current tests do not fail will require further work.

```python
def test_fix_xarray():
    import flox.xarray
    import xarray as xr
    import numpy as np

    sa=10
    sb=13
    sc=3

    x=xr.Dataset({
        'v0':xr.DataArray(((np.arange(sa*sb*sc)/sa)%1).reshape((sa,sb,sc)),dims=('a','b','c')),
        'v1':xr.DataArray((np.arange(sa*sb)%3).reshape(sa,sb),dims=('a','b')),
    })

    r=flox.xarray.xarray_reduce(x['v0'],
                              x['v1'],x['v0'],
                              expected_groups=(np.arange(6),np.linspace(0,1,num=5)),
                              isbin=[False,True],
                              func='count',
                              dim='b',
                              fill_value=np.nan,
                             ).mean('a',skipna=True)
    assert len(r['v1'])==6
test_fix_xarray()
```